### PR TITLE
Updated OpenVPN.Certificates.WLVPN version to 1.1.0

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -861,7 +861,7 @@
       <Version>2.4.6.3</Version>
     </PackageReference>
     <PackageReference Include="OpenVPN.Certificates.WLVPN">
-      <Version>1.0.0</Version>
+      <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="PropertyChanged.Fody">
       <Version>2.6.0</Version>


### PR DESCRIPTION
Updated OpenVPN.Certificates.WLVPN version to 1.1.0 which will expire in 2082