### PR TITLE
Syntax change in build.cmd 

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,5 @@
 #tool nuget:?package=NUnit.ConsoleRunner&version=3.4.0
 #addin nuget:?package=Cake.VersionReader
-#addin "Cake.FileHelpers"
 using System.Xml.Linq;
 using System.Xml;
 using System.Security.Cryptography;

--- a/build.cmd
+++ b/build.cmd
@@ -5,4 +5,4 @@ Powershell -ExecutionPolicy Unrestricted -file build.ps1 --dryrun
 GOTO :Execute
 
 :Execute
-.\tools\Cake\Cake.exe build.cake -Configuration="Release" -CertPassword="" -MyGetApiKey="" -verbosity=diagnostic -ApplicationName="ConsumerVPN" -EVCert=false
+.\tools\Cake\Cake.exe build.cake --Configuration="Release" --CertPassword="" --MyGetApiKey="" --verbosity=diagnostic  --ApplicationName="ConsumerVPN" --EVCert=false


### PR DESCRIPTION
- Done syntax change in build.cmd added double-dash(--) instead of a single dash(-)
- Removed the unused addin #addin "Cake.FileHelpers" from build.cake file