### PR TITLE
Added LastSelectedServer setting 

### DIFF
--- a/src/App/App.config
+++ b/src/App/App.config
@@ -91,6 +91,9 @@
         <setting name="DnsMonitoring" serializeAs="String">
           <value>False</value>
         </setting>
+        <setting name="LastSelectedServer" serializeAs="String">
+          <value />
+        </setting>
       </WLVPN.Properties.Settings>
     </userSettings>
   <runtime>

--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -962,7 +962,7 @@
       <Version>1.3.7</Version>
     </PackageReference>
     <PackageReference Include="VpnSDK">
-      <Version>2.2.40</Version>
+      <Version>2.2.42</Version>
     </PackageReference>
     <PackageReference Include="VpnSDK.Private.OpenVpn">
       <Version>1.0.39</Version>

--- a/src/App/Extensions/SDKExtensions.cs
+++ b/src/App/Extensions/SDKExtensions.cs
@@ -1,20 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using WLVPN.Interfaces;
 using WLVPN.Properties;
 using Serilog;
-using VpnSDK;
-using VpnSDK.Enums;
-using VpnSDK.Interfaces;
 using MessageBoxOptions = WLVPN.Enums.MessageBoxOptions;
 using System.Globalization;
-using WLVPN.ViewModels;
+using VpnSDK.Interfaces;
+using VpnSDK;
+using VpnSDK.Enums;
 
 namespace WLVPN.Extensions
 {
@@ -22,6 +18,7 @@ namespace WLVPN.Extensions
     {
         private static CancellationTokenSource TokenSource { get; set; }
         private static IDialogManager _dialog = AppBootstrapper.ContainerInstance.GetInstance<IDialogManager>();
+        private const string BestAvailable = "bestavailable";
 
         public static CancellationTokenSource GetCancellationTokenSource(this ISDK sdk)
         {
@@ -191,6 +188,11 @@ namespace WLVPN.Extensions
                 // Else, connect to a VPN server using a specific Network connection type.
                 var connectionType = configurations.First(x => x.ConnectionType == Properties.Settings.Default.ConnectionProtocol);
                 await sdk.Connect(locations ?? new List<ILocation>() { location }, connectionType, token);
+            }
+            if (location != null && location.Id != BestAvailable)
+            {
+                Properties.Settings.Default.LastSelectedServer = ((IChildren<IServer>)location).Children.FirstOrDefault().ToString();
+                Properties.Settings.Default.Save();
             }
         }
 

--- a/src/App/Properties/Settings.Designer.cs
+++ b/src/App/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace WLVPN.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -366,6 +366,18 @@ namespace WLVPN.Properties {
             }
             set {
                 this["SelectedDestination"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LastSelectedServer {
+            get {
+                return ((string)(this["LastSelectedServer"]));
+            }
+            set {
+                this["LastSelectedServer"] = value;
             }
         }
     }

--- a/src/App/Properties/Settings.settings
+++ b/src/App/Properties/Settings.settings
@@ -89,5 +89,8 @@
     <Setting Name="SelectedDestination" Type="VpnSDK.Interfaces.ILocation" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="LastSelectedServer" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/App/ViewModels/MainViewModel.cs
+++ b/src/App/ViewModels/MainViewModel.cs
@@ -23,6 +23,7 @@ namespace WLVPN.ViewModels
     {
         private readonly ISDK _sdk;
 
+        private const string BestAvailable = "bestavailable";
         public IDialogManager Dialog { get; }
 
         public ConnectionStatus VpnConnectionStatus { get; set; } = ConnectionStatus.Disconnected;
@@ -52,7 +53,11 @@ namespace WLVPN.ViewModels
             {
                 if (Properties.Settings.Default.StartupType == StartupType.LastLocation)
                 {
-                    await _sdk.InitiateConnection();
+                    var lastLocation = _sdk.Locations.Where(i => i.Id != BestAvailable)
+                        .FirstOrDefault(location => ((IChildren<IServer>)location).Children
+                        .Any(child => child.ToString() == Properties.Settings.Default.LastSelectedServer));
+
+                    await _sdk.InitiateConnection(lastLocation);
                 }
                 else
                 {


### PR DESCRIPTION
Updated VPNSDK version to 2.2.42
In the Application when the user selects Connect to the last selected server on startup it is not working properly. 
Added LastSelectedServer setting and on connection saved the server details and on startup set it so the auto connection to the last server can happen.