### PR TITLE
Update VpnSDK version to 2.2.48, VpnSDK.Private.OpenVpn and VpnHostService and Serilog update

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -912,7 +912,7 @@
       <Version>0.16.3</Version>
     </PackageReference>
     <PackageReference Include="OpenVPN.Binaries.Scramble">
-      <Version>2.5.6</Version>
+      <Version>2.5.7</Version>
     </PackageReference>
     <PackageReference Include="OpenVPN.Certificates.WLVPN">
       <Version>1.1.1</Version>
@@ -929,7 +929,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Serilog">
-      <Version>2.8.0</Version>
+      <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Enrichers.Process">
       <Version>2.0.1</Version>
@@ -938,13 +938,13 @@
       <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Formatting.Compact">
-      <Version>1.0.1-dev-00925</Version>
+      <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.Console">
-      <Version>3.1.1</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
-      <Version>4.0.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.Observable">
       <Version>2.0.2</Version>
@@ -965,13 +965,13 @@
       <Version>2.8.10</Version>
     </PackageReference>
     <PackageReference Include="VpnHostService">
-      <Version>1.3.9</Version>
+      <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="VpnSDK">
-      <Version>2.2.47</Version>
+      <Version>2.2.48</Version>
     </PackageReference>
     <PackageReference Include="VpnSDK.Private.OpenVpn">
-      <Version>1.0.41</Version>
+      <Version>1.0.43</Version>
     </PackageReference>
     <PackageReference Include="WPFLocalizeExtension">
       <Version>3.3.1</Version>


### PR DESCRIPTION
* Updated the SDK to version v2.2.48.
* Updated the OpenVPN.Binaries.Scramble NuGet package to version 2.5.7.
* Updated the VpnSDK.Private.OpenVpn NuGet package to version 1.0.43.
* Updated the VpnHostService NuGet package to version 1.4.1.
